### PR TITLE
Don't log errors related to overrides.properties

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+  <!-- Don't log messages and errors when loading properties files, and they can't be found-->
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <property resource="application.properties"/>
   <property file="overrides.properties"/>
 


### PR DESCRIPTION
This silences the first lines of logback log configuration,
where it typically spews out a long list of non-json with errors related to overrides.properties
not being present.