### PR TITLE
Replace ktlint with ktfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,3 @@ TODO
 
 ## License
 Apache Licence. See LICENCE file
-

--- a/pom.xml
+++ b/pom.xml
@@ -36,21 +36,28 @@
     <kotlin.code.style>official</kotlin.code.style>
     <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
-    <kotlin.version>1.6.21</kotlin.version>
+    <kotlin.version>1.8.10</kotlin.version>
 
-    <!-- application -->
+    <!-- Liflig-dependencies -->
     <liflig.properties.version>2.20230214.071539</liflig.properties.version>
+    <liflig-snapshot-test.version>1.20230209.211009</liflig-snapshot-test.version>
+
+    <!-- App -->
     <aws-lambda-events.version>3.11.0</aws-lambda-events.version>
     <kotlin-logging.version>2.1.23</kotlin-logging.version>
     <logback.version>1.4.5</logback.version>
+    <slf4j.version>2.0.6</slf4j.version>
     <jackson.version>2.14.2</jackson.version>
     <logstash.version>7.2</logstash.version>
-    <slf4j.version>2.0.6</slf4j.version>
 
-    <!--testing-->
+    <!-- Testing-dependencies -->
     <assertj.version>3.24.2</assertj.version>
     <junit.version>5.9.2</junit.version>
-    <liflig-snapshot-test.version>1.20230209.211009</liflig-snapshot-test.version>
+    <mockk.version>1.13.1</mockk.version>
+
+    <!-- Maven -->
+    <spotless-maven-plugin.version>2.33.0</spotless-maven-plugin.version>
+    <ktfmt.version>0.43</ktfmt.version>
   </properties>
 
   <repositories>
@@ -76,23 +83,8 @@
       <artifactId>kotlin-stdlib</artifactId>
       <version>${kotlin.version}</version>
     </dependency>
-    <dependency>
-      <groupId>no.liflig</groupId>
-      <artifactId>properties</artifactId>
-      <version>${liflig.properties.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-lambda-java-events</artifactId>
-      <version>${aws-lambda-events.version}</version>
-    </dependency>
 
-    <!-- LOGGING -->
-    <dependency>
-      <groupId>io.github.microutils</groupId>
-      <artifactId>kotlin-logging-jvm</artifactId>
-      <version>${kotlin-logging.version}</version>
-    </dependency>
+    <!-- Logging -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -105,15 +97,31 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>io.github.microutils</groupId>
+      <artifactId>kotlin-logging-jvm</artifactId>
+      <version>${kotlin-logging.version}</version>
+    </dependency>
+    <dependency>
       <groupId>net.logstash.logback</groupId>
       <artifactId>logstash-logback-encoder</artifactId>
       <version>${logstash.version}</version>
     </dependency>
-    <!-- Needed by logstash -->
     <dependency>
+    <!-- Needed by logstash -->
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>no.liflig</groupId>
+      <artifactId>properties</artifactId>
+      <version>${liflig.properties.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-lambda-java-events</artifactId>
+      <version>${aws-lambda-events.version}</version>
     </dependency>
 
     <!-- Testing -->
@@ -135,7 +143,13 @@
       <version>${assertj.version}</version>
       <scope>test</scope>
     </dependency>
-    
+    <dependency>
+      <groupId>io.mockk</groupId>
+      <artifactId>mockk-jvm</artifactId>
+      <version>${mockk.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- For testing JSON -->
     <dependency>
       <groupId>no.liflig</groupId>
@@ -270,6 +284,54 @@
             <configuration>
               <outputFile>${project.build.outputDirectory}/pom.properties</outputFile>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- spotless with ktfmt for code style -->
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <formats>
+            <format>
+              <includes>
+                <include>*.md</include>
+                <include>.gitignore</include>
+              </includes>
+              <trimTrailingWhitespace/>
+              <endWithNewline/>
+              <indent>
+                <spaces>true</spaces>
+                <spacesPerTab>2</spacesPerTab>
+              </indent>
+            </format>
+          </formats>
+          <kotlin>
+            <ktfmt>
+              <version>${ktfmt.version}</version>
+              <style>DEFAULT</style>
+            </ktfmt>
+          </kotlin>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.github.gantsign.maven</groupId>
+        <artifactId>ktlint-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- Disable ktlint defined in the parent pom -->
+            <id>check</id>
+            <phase>none</phase>
           </execution>
         </executions>
       </plugin>

--- a/src/main/kotlin/no/liflig/example/Config.kt
+++ b/src/main/kotlin/no/liflig/example/Config.kt
@@ -8,24 +8,26 @@ import no.liflig.properties.stringNotNull
 /**
  * Loads config using Liflig Properties
  *
- * @see <a href="https://github.com/capralifecycle/liflig-properties">Liflig Properties on Github</a>
+ * @see <a href="https://github.com/capralifecycle/liflig-properties">Liflig Properties on
+ *   Github</a>
  */
 object Config {
   private val properties = loadProperties()
 
-  val build = Build(
-    timestamp = properties.stringNotNull("build.timestamp"),
-    commit = properties.stringNotNull("build.commit"),
-    branch = properties.stringNotNull("build.branch"),
-    buildNumber = properties.intRequired("build.number"),
-  )
+  val build =
+      Build(
+          timestamp = properties.stringNotNull("build.timestamp"),
+          commit = properties.stringNotNull("build.commit"),
+          branch = properties.stringNotNull("build.branch"),
+          buildNumber = properties.intRequired("build.number"),
+      )
 
   val exampleProp = properties.stringNotEmpty("example.prop")
 }
 
 data class Build(
-  val timestamp: String,
-  val commit: String,
-  val branch: String,
-  val buildNumber: Int,
+    val timestamp: String,
+    val commit: String,
+    val branch: String,
+    val buildNumber: Int,
 )

--- a/src/main/kotlin/no/liflig/example/Handler.kt
+++ b/src/main/kotlin/no/liflig/example/Handler.kt
@@ -4,11 +4,9 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import mu.KotlinLogging
 import net.logstash.logback.marker.Markers
 
-private val log = KotlinLogging.logger { }
+private val log = KotlinLogging.logger {}
 
-/**
- * Entrypoint for AWS Lambda.
- */
+/** Entrypoint for AWS Lambda. */
 @Suppress("unused") // Called by AWS Lambda
 fun handler(sqsEvent: SQSEvent) {
   log.info(Markers.append("build", Config.build)) { "Hello ${Config.exampleProp}" }

--- a/src/test/kotlin/DummyTest.kt
+++ b/src/test/kotlin/DummyTest.kt
@@ -2,9 +2,7 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import no.liflig.example.handler
 import org.junit.jupiter.api.Test
 
-/**
- * A simple dummy test to make sure we have atleast one test so that SonarCloud can be set up
- */
+/** A simple dummy test to make sure we have atleast one test so that SonarCloud can be set up */
 class DummyTest {
 
   @Test


### PR DESCRIPTION
This plugin should have less friction compared to ktlint.

Install the ktfmt plugin.
Then, just run reformat with IntelliJ.

Same as https://github.com/capralifecycle/liflig-rest-service-baseline/pull/30 